### PR TITLE
remove empty 'conflicts' - dpkg complains in 14.04

### DIFF
--- a/src/DEBIAN/control
+++ b/src/DEBIAN/control
@@ -3,7 +3,6 @@ Version: 14.0.__datestamp__
 Architecture: all
 Maintainer: Paul Weaver <paul.weaver.uk@gmail.com>
 Depends: libnet-snmp-perl, liblog-log4perl-perl, libsnmp-info-perl, liblog-dispatch-perl, netdiscover, apache2, snmp-mibs-downloader, snmp, libjson-perl
-Conflicts:
 Recommends: netdisco-mibs-installer
 Section: web
 Priority: optional


### PR DESCRIPTION
I get this:

E: Problem parsing dependency Conflicts
E: Error occurred while processing switchmap (NewVersion2)
E: Problem with MergeList /var/lib/apt/lists/buildwest.bcn.bbc.co.uk_dists_trusty_main_binary-amd64_Packages
E: The package lists or status file could not be parsed or opened.